### PR TITLE
Update config to find fmod headers explicitly

### DIFF
--- a/nwnexplorer/nwnexplorer.vcxproj
+++ b/nwnexplorer/nwnexplorer.vcxproj
@@ -70,6 +70,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(ProjectDir)include\fmod</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalOptions>/FIXED:NO %(AdditionalOptions)</AdditionalOptions>
@@ -95,6 +96,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(ProjectDir)include\fmod</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>fmodvc.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Update config to find fmod headers explicitly.

This is my attempt to follow up on @virusman 's suggestion here: https://github.com/virusman/nwnexplorer/pull/6/commits#pullrequestreview-1602036579

This change allows nwnexplorer to compile locally on my computer in Microsoft Visual Studio 2022 without adding the full path ("include/fmod/fmod.h") to source files elsewhere.